### PR TITLE
Migration from practice repo

### DIFF
--- a/StreamingVideoPlayer/package-lock.json
+++ b/StreamingVideoPlayer/package-lock.json
@@ -3038,8 +3038,7 @@
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
-      "dev": true
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
     },
     "events": {
       "version": "3.0.0",
@@ -4390,6 +4389,15 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "hls.js": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.12.4.tgz",
+      "integrity": "sha512-e8OPxQ60dBVsdkv4atdxR21KzC1mgwspM41qpozpj3Uv1Fz4CaeQy3FWoaV2O+QKKbNRvV5hW+/LipCWdrwnMQ==",
+      "requires": {
+        "eventemitter3": "3.1.0",
+        "url-toolkit": "^2.1.6"
       }
     },
     "hmac-drbg": {
@@ -9592,6 +9600,11 @@
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
       }
+    },
+    "url-toolkit": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.1.6.tgz",
+      "integrity": "sha512-UaZ2+50am4HwrV2crR/JAf63Q4VvPYphe63WGeoJxeu8gmOm0qxPt+KsukfakPNrX9aymGNEkkaoICwn+OuvBw=="
     },
     "use": {
       "version": "3.1.1",

--- a/StreamingVideoPlayer/package.json
+++ b/StreamingVideoPlayer/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",
     "core-js": "^2.5.4",
+    "hls.js": "^0.12.4",
     "rxjs": "~6.3.3",
     "tslib": "^1.9.0",
     "zone.js": "~0.8.26"

--- a/StreamingVideoPlayer/src/app/app.component.html
+++ b/StreamingVideoPlayer/src/app/app.component.html
@@ -7,6 +7,6 @@
     <app-video></app-video>
   </main>
   <aside>
-
+    <app-video-options></app-video-options>
   </aside>
 </div>

--- a/StreamingVideoPlayer/src/app/app.component.html
+++ b/StreamingVideoPlayer/src/app/app.component.html
@@ -4,7 +4,7 @@
     <h1>StreamPlayer</h1>
   </header>
   <main>
-
+    <app-video></app-video>
   </main>
   <aside>
 

--- a/StreamingVideoPlayer/src/app/video-options/video-options.component.css
+++ b/StreamingVideoPlayer/src/app/video-options/video-options.component.css
@@ -1,0 +1,52 @@
+.video-list {
+  background-color: #CECECE;
+  height: 400px;
+  width: 90%;
+  margin-top: 50px;
+  box-shadow: 0 0 7px 1px #00000075
+}
+
+.playlist-header {
+  height: 65px;
+  background-color: #4A5B63;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  padding-left: 10px;
+}
+
+h2 {
+  color: #43A9FE;
+  font-size: 2rem;
+  margin-left: 10px;
+  font-family: 'Lobster', cursive;
+}
+
+.playlist-icon {
+  height: 30px;
+}
+
+.video-option-1, .video-option-2 {
+  height: 65px;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-evenly;
+}
+
+.video-option-1 {
+  background-color: #FCFEFC;
+}
+
+.still-frame {
+  height: 50px;
+}
+
+.video-option-2 {
+  background-color: #E5E5E5;
+}
+
+.arte-china-still {
+  margin-right: 35px;
+}

--- a/StreamingVideoPlayer/src/app/video-options/video-options.component.html
+++ b/StreamingVideoPlayer/src/app/video-options/video-options.component.html
@@ -1,3 +1,14 @@
-<p>
-  video-options works!
-</p>
+<div class="video-list">
+  <div class="playlist-header">
+    <img class="playlist-icon" src="./assets/playlist.svg" alt="playlist icon">
+    <h2>Playlist</h2>
+  </div>
+  <div class="video-option-1">
+    <img class="still-frame" src="./assets/bbb-frame.png" alt="Big Buck Bunny Still">
+    <p class="video-title">Big Buck Bunny</p>
+  </div>
+  <div class="video-option-2">
+    <img class="still-frame arte-china-still" src="./assets/arte-china-frame.jpg" alt="Arte China Still">
+    <p class="video-title">Arte China</p>
+  </div>
+</div>

--- a/StreamingVideoPlayer/src/app/video.service.ts
+++ b/StreamingVideoPlayer/src/app/video.service.ts
@@ -9,8 +9,8 @@ export class VideoService {
 
   constructor() { }
 
-  attachVideo(): void {
-    let video = new Video(
+  attachVideo(): Video {
+    let newVideo = new Video(
       document.querySelector('.video-main'),
       document.querySelector('.current-time'),
       document.querySelector('.progress-fg'),
@@ -21,5 +21,6 @@ export class VideoService {
       document.querySelector('.draggable-circle'),
       false
     )
+    return newVideo
   }
 }

--- a/StreamingVideoPlayer/src/app/video.service.ts
+++ b/StreamingVideoPlayer/src/app/video.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+import { Video } from "./video"
+
 
 @Injectable({
   providedIn: 'root'
@@ -6,4 +8,18 @@ import { Injectable } from '@angular/core';
 export class VideoService {
 
   constructor() { }
+
+  attachVideo(): void {
+    let video = new Video(
+      document.querySelector('.video-main'),
+      document.querySelector('.current-time'),
+      document.querySelector('.progress-fg'),
+      document.querySelector('.progress-bg'),
+      document.querySelector('.duration'),
+      document.querySelector('.play-btn'),
+      document.querySelector('.play-icon'),
+      document.querySelector('.draggable-circle'),
+      false
+    )
+  }
 }

--- a/StreamingVideoPlayer/src/app/video.ts
+++ b/StreamingVideoPlayer/src/app/video.ts
@@ -1,4 +1,5 @@
 export class Video {
+
   constructor(
     public video: HTMLVideoElement,
     public vidCurrentTime: HTMLParagraphElement,
@@ -19,4 +20,5 @@ export class Video {
       this.draggableCircle = draggableCircle;
       this.isDragging = isDragging;
   }
+
 }

--- a/StreamingVideoPlayer/src/app/video.ts
+++ b/StreamingVideoPlayer/src/app/video.ts
@@ -1,11 +1,22 @@
 export class Video {
-  video: HTMLVideoElement;
-  vidCurrentTime: HTMLParagraphElement;
-  vidProgress: HTMLParagraphElement;
-  seekBar: HTMLDivElement;
-  vidDuration: HTMLDivElement;
-  playButton: HTMLButtonElement;
-  playButtonIcon: HTMLImageElement;
-  draggableCircle: HTMLImageElement;
-  isDragging: boolean
+  constructor(
+    public video: HTMLVideoElement,
+    public vidCurrentTime: HTMLParagraphElement,
+    public vidProgress: HTMLParagraphElement,
+    public seekBar: HTMLDivElement,
+    public vidDuration: HTMLDivElement,
+    public playButton: HTMLButtonElement,
+    public playButtonIcon: HTMLImageElement,
+    public draggableCircle: HTMLImageElement,
+    public isDragging: boolean) {
+      this.video = video;
+      this.vidCurrentTime = vidCurrentTime;
+      this.vidProgress = vidProgress;
+      this.seekBar = seekBar;
+      this.vidDuration = vidDuration;
+      this.playButton = playButton;
+      this.playButtonIcon = playButtonIcon;
+      this.draggableCircle = draggableCircle;
+      this.isDragging = isDragging;
+  }
 }

--- a/StreamingVideoPlayer/src/app/video/video.component.css
+++ b/StreamingVideoPlayer/src/app/video/video.component.css
@@ -1,0 +1,80 @@
+.video-holder {
+  background-color: black;
+  height: 500px;
+  width: 900px;
+  margin-top: 50px;
+  margin-left: 30px;
+  box-shadow: 0px 2px 4px #00000078;
+}
+
+.video-main {
+  width: 900px;
+}
+
+.video-holder .video-controls {
+  opacity: 0;
+  transition: all .5s;
+}
+
+.video-holder:hover .video-controls {
+  opacity: 1;
+  transition: all .5s;
+
+}
+
+.video-controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  position: relative;
+  bottom: 48px;
+  margin-left: 10px;
+}
+
+.play-btn {
+  height: 30px;
+  border: none;
+  background-color: transparent;
+}
+
+.progress-bg {
+  width: 80%;
+  background-color: #E3EFEF;
+  height: 20px;
+  margin-right: 10px;
+  margin-left: 10px;
+}
+
+.draggable-circle {
+  height: 21px;
+  width: 30px;
+  z-index: 10;
+  cursor: pointer;
+  position: absolute;
+  left: 4.3%;
+}
+
+.progress-fg {
+  background-color: #43A9FE;
+  height: 100%;
+  width: 0%;
+}
+
+.current-time, .duration, .slash {
+  color: #E3EFEF;
+  font-size: 1rem;
+  padding-left: 3px;
+
+}
+
+button {
+  outline: none;
+}
+
+button, .progress-bg, .video-option-1, .video-option-2 {
+  cursor: pointer;
+}
+
+.play-icon {
+  height: 30px;
+}

--- a/StreamingVideoPlayer/src/app/video/video.component.html
+++ b/StreamingVideoPlayer/src/app/video/video.component.html
@@ -1,7 +1,9 @@
 <div class="video-holder">
   <video class="video-main" ></video>
   <div class="video-controls">
-    <button class="play-btn"><img class="play-icon" src="./assets/play-sign.svg" alt="play icon"></button>
+    <button class="play-btn">
+      <img class="play-icon" src="./assets/play-sign.svg" alt="play icon">
+    </button>
     <div class="progress-bg">
       <img class="draggable-circle" src="assets/circle.svg" alt="draggable-circle">
       <div class="progress-fg"></div>

--- a/StreamingVideoPlayer/src/app/video/video.component.html
+++ b/StreamingVideoPlayer/src/app/video/video.component.html
@@ -1,7 +1,7 @@
 <div class="video-holder">
   <video class="video-main" ></video>
   <div class="video-controls">
-    <button class="play-btn">
+    <button class="play-btn" (click)='togglePlaying()'>
       <img class="play-icon" src="./assets/play-sign.svg" alt="play icon">
     </button>
     <div class="progress-bg">
@@ -12,3 +12,18 @@
     <p class="slash">/</p>
     <p class="duration">0:00</p>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script>
+    if(Hls.isSupported()) {
+      console.log('supported')
+      let hls = new Hls();
+      hls.attachMedia(document.querySelector('.video-main'));
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+        console.log("video and hls.js are now bound together !");
+        hls.loadSource("https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8");
+        hls.on(Hls.Events.MANIFEST_PARSED, function (event, data) {
+          console.log("manifest loaded, found " + data.levels.length + " quality level");
+        });
+      });
+    }
+  </script>

--- a/StreamingVideoPlayer/src/app/video/video.component.html
+++ b/StreamingVideoPlayer/src/app/video/video.component.html
@@ -1,3 +1,12 @@
-<p>
-  video works!
-</p>
+<div class="video-holder">
+  <video class="video-main" ></video>
+  <div class="video-controls">
+    <button class="play-btn"><img class="play-icon" src="./assets/play-sign.svg" alt="play icon"></button>
+    <div class="progress-bg">
+      <img class="draggable-circle" src="assets/circle.svg" alt="draggable-circle">
+      <div class="progress-fg"></div>
+    </div>
+    <p class="current-time">0:00</p>
+    <p class="slash">/</p>
+    <p class="duration">0:00</p>
+  </div>

--- a/StreamingVideoPlayer/src/app/video/video.component.ts
+++ b/StreamingVideoPlayer/src/app/video/video.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Video } from '../video';
+import { VideoService } from '../video.service'
 
 @Component({
   selector: 'app-video',
@@ -7,9 +9,12 @@ import { Component, OnInit } from '@angular/core';
 })
 export class VideoComponent implements OnInit {
 
-  constructor() { }
+  video: Video;
+
+  constructor(private VideoService: VideoService ) { }
 
   ngOnInit() {
+    this.VideoService.attachVideo();
   }
 
 }

--- a/StreamingVideoPlayer/src/app/video/video.component.ts
+++ b/StreamingVideoPlayer/src/app/video/video.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Video } from '../video';
-import { VideoService } from '../video.service'
+import { VideoService } from '../video.service';
+import { Hls } from 'hls.js'
 
 @Component({
   selector: 'app-video',
@@ -12,15 +13,34 @@ export class VideoComponent implements OnInit {
   video: Video;
   videos: Video[];
 
-  constructor(private VideoService: VideoService ) {
+  constructor(private VideoService: VideoService, ) {
     this.videos = []
    }
 
 
   ngOnInit() {  
     this.videos.push(this.VideoService.attachVideo());
+      let hls = new Hls();
+
+      hls.attachMedia(this.videos[0].video);
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+        console.log("video and hls.js are now bound together !");
+        hls.loadSource("https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8");
+        hls.on(Hls.Events.MANIFEST_PARSED, function (event, data) {
+          console.log("manifest loaded, found " + data.levels.length + " quality level");
+        });
+      });
+
   }
 
-  
+  togglePlaying(): void {
+    if(this.videos[0].video.paused){
+      this.videos[0].video.play();
+      this.videos[0].playButtonIcon.setAttribute('src', './assets/pause.svg')
+    } else {
+      this.videos[0].video.pause();
+      this.videos[0].playButtonIcon.setAttribute('src', './assets/play-sign.svg')
+    }
+  }
 
 }

--- a/StreamingVideoPlayer/src/app/video/video.component.ts
+++ b/StreamingVideoPlayer/src/app/video/video.component.ts
@@ -10,11 +10,17 @@ import { VideoService } from '../video.service'
 export class VideoComponent implements OnInit {
 
   video: Video;
+  videos: Video[];
 
-  constructor(private VideoService: VideoService ) { }
+  constructor(private VideoService: VideoService ) {
+    this.videos = []
+   }
 
-  ngOnInit() {
-    this.VideoService.attachVideo();
+
+  ngOnInit() {  
+    this.videos.push(this.VideoService.attachVideo());
   }
+
+  
 
 }

--- a/StreamingVideoPlayer/src/index.html
+++ b/StreamingVideoPlayer/src/index.html
@@ -10,5 +10,20 @@
 </head>
 <body>
   <app-root></app-root>
+  <script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+  <script>
+    if(Hls.isSupported()) {
+      console.log('supported')
+      let hls = new Hls();
+      hls.attachMedia(document.querySelector('.video-main'));
+      hls.on(Hls.Events.MEDIA_ATTACHED, function () {
+        console.log("video and hls.js are now bound together !");
+        hls.loadSource("https://video-dev.github.io/streams/x36xhzz/x36xhzz.m3u8");
+        hls.on(Hls.Events.MANIFEST_PARSED, function (event, data) {
+          console.log("manifest loaded, found " + data.levels.length + " quality level");
+        });
+      });
+    }
+  </script>
 </body>
 </html>

--- a/StreamingVideoPlayer/src/styles.css
+++ b/StreamingVideoPlayer/src/styles.css
@@ -7,6 +7,7 @@ body {
 }
 
 .main-container {
+  height: 100vh;
   display: grid;
   grid-template-columns: 1fr 300px;
   grid-template-rows: 100px 1fr;


### PR DESCRIPTION
Began migration and buildout of video player in angular. Got to the point of adding the play functionality and attaching the HLS media content, just to see if it would work. Attempted putting it in various places. When in the Component file it did not recognize HLS as it did in the vanilla JS version I did. I tried using an NPM package but it gave me an error saying it is a webpack imported module and not a constructor, so the 'new' keyword could not be used as was used in the example and the practice version I made.

I tried doing it in the script tag in a component as well, but that was unsuccessful. (I also thought that would not be the best practice). the only way i could get Hls.isSupported() to return a boolean of true was in the index.html file all the way in the src file, and I DEFINITELY didn't think that'd be ideal. Still, just wanted to show some of my beginner angular capabilities. 